### PR TITLE
Catch `Throwable` when using the AWT classes

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
@@ -63,7 +63,7 @@ public class SXSSFSheet implements Sheet, OoxmlSheetExtensions {
         setRandomAccessWindowSize(randomAccessWindowSize);
         try {
             _autoSizeColumnTracker = new AutoSizeColumnTracker(this);
-        } catch (InternalError e) {
+        } catch (Throwable e) {
             LOG.atWarn().log("Failed to create AutoSizeColumnTracker, possibly due to fonts not being installed in your OS", e);
         }
     }


### PR DESCRIPTION
`ERROR: java.lang.UnsatisfiedLinkError: no awt in java.library.path` is thrown when attempting to build a native image that depends on AWT on macOS.

See the following issue for more details:

- https://github.com/oracle/graal/issues/4124
